### PR TITLE
Boto no longer needs env variables, will check all locations

### DIFF
--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -43,7 +43,7 @@ class S3Grabber(object):
         base = urlparse.urlsplit(baseurl)
         self.baseurl = baseurl
         self.basepath = base.path.lstrip('/')
-        self.bucket = boto.connect_s3(os.environ['AWS_ACCESS_KEY'], os.environ['AWS_SECRET_KEY']).get_bucket(base.netloc)
+        self.bucket = boto.connect_s3().get_bucket(base.netloc)
         self.visibility = visibility
 
     def check(self, url):

--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -43,7 +43,7 @@ class S3Grabber(object):
         base = urlparse.urlsplit(baseurl)
         self.baseurl = baseurl
         self.basepath = base.path.lstrip('/')
-        self.bucket = boto.connect_s3().get_bucket(base.netloc)
+        self.bucket = getclient(base)
         self.visibility = visibility
 
     def check(self, url):
@@ -104,6 +104,14 @@ class FileGrabber(object):
         # the base path from its own tempdir, etc.
         os.symlink(realfilename, filename)
         return filename
+
+
+def getclient(base):
+    if os.getenv('AWS_ACCESS_KEY'):
+        return boto.connect_s3(os.getenv('AWS_ACCESS_KEY'), os.getenv('AWS_SECRET_KEY').get_bucket(base.netloc))
+    else:
+        return boto.connect_s3().get_bucket(base.netloc)
+
 
 def sign(rpmfile):
     """Requires a proper ~/.rpmmacros file. See <http://fedoranews.org/tchung/gpg/>"""


### PR DESCRIPTION
Boto is now a robust aws sdk and looks for  credentials in the following places (in this order)
 1.Credentials passed into constructor
 2.Environment variables for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (what was previously coded)
 3.Named profiles in the ~/.aws/credentials file (as specified)
 4.Default profile in the ~/.aws/credentials files
 5.Named profile in the boto config
 6.Default profile in boto config
 7.Instance profile credentials (if on EC2 instance)

We had to make this change because we are using instance profiles in AWS when building RPMs from our jenkins.   
