### PR TITLE
Make the "delete" option a proper boolean

### DIFF
--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -249,6 +249,6 @@ if __name__ == '__main__':
     parser.add_option('--visibility', default='private')
     parser.add_option('-s', '--sign', action='count', default=0)
     parser.add_option('-l', '--logfile')
-    parser.add_option('-d', '--delete', default=False)
+    parser.add_option('-d', '--delete', action='store_true', default=False)
     options, args = parser.parse_args()
     main(options, args)


### PR DESCRIPTION
PR #1 added a "delete" option to be able to remove RPMs from the repository (the author suggests using the '-d true' parameter for that). However, the usage of this new option is ambiguous, since using '-d false' does the exact same thing: deletes the package(s) passed as argument(s). This happens because the value of this parameter is interpreted as a string instead of a boolean.
